### PR TITLE
GET-385: addChannelMapping fix where it wouldn't register new channels f...

### DIFF
--- a/kixmpp-client/pom.xml
+++ b/kixmpp-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-core/pom.xml
+++ b/kixmpp-core/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-p2p/pom.xml
+++ b/kixmpp-p2p/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.kixeye.kixmpp</groupId>
         <artifactId>kixmpp-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.1</version>
     </parent>
 
     <developers>

--- a/kixmpp-server/pom.xml
+++ b/kixmpp-server/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/KixmppServer.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/KixmppServer.java
@@ -602,9 +602,9 @@ public class KixmppServer implements AutoCloseable, ClusterListener {
     		
     		if (channels == null) {
     			channels = new HashSet<>();
-    			channels.add(channel);
     		}
-    		
+        	channels.add(channel);
+
         	usernameChannel.put(jid.getNode(), channels);
     	} finally {
     		lock.unlock();

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kixeye.kixmpp</groupId>
 	<artifactId>kixmpp-parent</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.0.1</version>
 	<packaging>pom</packaging>
 	<name>KIXMPP Parent</name>
 	<description>


### PR DESCRIPTION
addChannelMapping fix where it wouldn't register new channels for a given jid node. PrivateMessageTask fix where fromJid and toJid were both the same, handling the operation in one ClusterTask, got rid of ReveiceMessageTask
