### PR TITLE
Supporting http://tools.ietf.org/html/draft-ietf-xmpp-websocket-00

### DIFF
--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/KixmppServer.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/KixmppServer.java
@@ -795,7 +795,7 @@ public class KixmppServer implements AutoCloseable, ClusterListener {
 	        }
 
 	        // Handshake
-	        WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req), null, false);
+	        WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req), "xmpp", false);
 	        handshaker = wsFactory.newHandshaker(req);
 	        
 	        if (handshaker == null) {


### PR DESCRIPTION
Added support for WebSocket subprotocol 'xmpp' which is expected by some libraries such as Strophe, switched to XMPP over WebSocket standards (http://tools.ietf.org/html/draft-ietf-xmpp-websocket-00) from RFC 7395 since most libraries implement stream:stream instead of xmpp-framing <open xmlns='urn:ietf:params:xml:ns:xmpp-framing' />
