### PR TITLE
Fixing MucRoom and MucRoomEventHandler

### DIFF
--- a/kixmpp-client/pom.xml
+++ b/kixmpp-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>3.0.0</version>
+		<version>4.0.0</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-core/pom.xml
+++ b/kixmpp-core/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>3.0.0</version>
+		<version>4.0.0</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-p2p/pom.xml
+++ b/kixmpp-p2p/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.kixeye.kixmpp</groupId>
         <artifactId>kixmpp-parent</artifactId>
-        <version>3.0.0</version>
+        <version>4.0.0</version>
     </parent>
 
     <developers>

--- a/kixmpp-server/pom.xml
+++ b/kixmpp-server/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>3.0.0</version>
+		<version>4.0.0</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/DefaultMucRoomEventHandler.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/DefaultMucRoomEventHandler.java
@@ -44,12 +44,13 @@ public class DefaultMucRoomEventHandler implements MucRoomEventHandler {
 	}
 
 	@Override
-	public void handleMessage(MucRoom room, KixmppJid from, String... messages) {
+	public void handleMessage(MucRoom room, KixmppJid sender, String... messages) {
+		KixmppJid fromRoomJid = room.getRoomJidWithNickname(sender);
 		for (MucRoom.User user: room.getUsers()) {
 			for (MucRoom.Client client: user.getConnections()) {
 				for (String message: messages) {
 					Element stanza = createMessage(UUID.randomUUID().toString(),
-							from,
+							fromRoomJid,
 							client.getAddress(),
 							"groupchat",
 							message);

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoom.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoom.java
@@ -415,10 +415,13 @@ public class MucRoom {
         
         mucModule.publishMessage(roomJid, fromRoomJid, fromNickname, messages);
 
-		receive(fromAddress, messages);
+	    MucRoomEventHandler handler = service.getServer().getMucRoomEventHandler();
+	    if (handler != null) {
+		    handler.handleMessage(this, fromAddress, messages);
+	    }
 
         if (sendToCluster) {
-            service.getServer().getCluster().sendMessageToAll(new RoomBroadcastTask(this, service.getSubDomain(), roomId, fromRoomJid, fromNickname, messages), false);
+            service.getServer().getCluster().sendMessageToAll(new RoomBroadcastTask(this, service.getSubDomain(), roomId, fromAddress, fromNickname, messages), false);
         }
     }
 

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoom.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoom.java
@@ -415,7 +415,7 @@ public class MucRoom {
         
         mucModule.publishMessage(roomJid, fromRoomJid, fromNickname, messages);
 
-		receive(fromRoomJid, messages);
+		receive(fromAddress, messages);
 
         if (sendToCluster) {
             service.getServer().getCluster().sendMessageToAll(new RoomBroadcastTask(this, service.getSubDomain(), roomId, fromRoomJid, fromNickname, messages), false);
@@ -481,6 +481,11 @@ public class MucRoom {
     public User getUser(String nickname) {
         return usersByNickname.get(nickname);
     }
+
+	public KixmppJid getRoomJidWithNickname(KixmppJid jid) {
+		String nickname = nicknamesByBareJid.get(jid.withoutResource());
+		return roomJid.withResource(nickname);
+	}
 
     public User getUser(KixmppJid jid) {
         String nickname = nicknamesByBareJid.get(jid.withoutResource());

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoomEventHandler.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoomEventHandler.java
@@ -23,7 +23,7 @@ package com.kixeye.kixmpp.server.module.muc;
 import com.kixeye.kixmpp.KixmppJid;
 
 public interface MucRoomEventHandler {
-	public void handleMessage(MucRoom room, KixmppJid from, String... messages);
+	public void handleMessage(MucRoom room, KixmppJid sender, String... messages);
 	public void userAdded(MucRoom room, MucRoom.User user);
 	public void userRemoved(MucRoom room, MucRoom.User user);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kixeye.kixmpp</groupId>
 	<artifactId>kixmpp-parent</artifactId>
-	<version>3.0.0</version>
+	<version>4.0.0</version>
 	<packaging>pom</packaging>
 	<name>KIXMPP Parent</name>
 	<description>


### PR DESCRIPTION
Fixing MucRoom and MucRoomEventHandler, sender jid is passed to the handler instead of room jid with sender nickname as resource