### PR TITLE
MucRoom fixes

### DIFF
--- a/kixmpp-client/pom.xml
+++ b/kixmpp-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>3.0.0</version>
+		<version>4.0.0</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-core/pom.xml
+++ b/kixmpp-core/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>3.0.0</version>
+		<version>4.0.0</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-p2p/pom.xml
+++ b/kixmpp-p2p/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.kixeye.kixmpp</groupId>
         <artifactId>kixmpp-parent</artifactId>
-        <version>3.0.0</version>
+        <version>4.0.0</version>
     </parent>
 
     <developers>

--- a/kixmpp-server/pom.xml
+++ b/kixmpp-server/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>3.0.0</version>
+		<version>4.0.0</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/cluster/message/RoomBroadcastPresenceTask.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/cluster/message/RoomBroadcastPresenceTask.java
@@ -1,0 +1,61 @@
+package com.kixeye.kixmpp.server.cluster.message;
+
+/*
+ * #%L
+ * KIXMPP
+ * %%
+ * Copyright (C) 2014 KIXEYE, Inc
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.kixeye.kixmpp.KixmppJid;
+import com.kixeye.kixmpp.server.module.muc.MucRole;
+import com.kixeye.kixmpp.server.module.muc.MucRoom;
+
+public class RoomBroadcastPresenceTask extends RoomTask {
+
+	private KixmppJid from;
+	private MucRole role;
+	private String type;
+
+	public RoomBroadcastPresenceTask() {
+	}
+
+	public RoomBroadcastPresenceTask(MucRoom room, String gameId, String roomId, KixmppJid from, MucRole role, String type) {
+		super(room, gameId, roomId);
+		this.from = from;
+		this.role = role;
+		this.type = type;
+	}
+
+	@Override
+	public void run() {
+		getRoom().receivePresence(from, role, type);
+	}
+
+	/**
+	 * @return the from
+	 */
+	public KixmppJid getFrom() {
+		return from;
+	}
+
+	/**
+	 * @param from the from to set
+	 */
+	public void setFrom(KixmppJid from) {
+		this.from = from;
+	}
+}

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/cluster/message/RoomBroadcastTask.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/cluster/message/RoomBroadcastTask.java
@@ -26,37 +26,39 @@ import com.kixeye.kixmpp.server.module.muc.MucRoom;
 
 public class RoomBroadcastTask extends RoomTask {
 
-    private KixmppJid from;
+	private KixmppJid fromJid;
+    private KixmppJid fromRoomJid;
     private String nickname;
     private String[] messages;
 
     public RoomBroadcastTask() {
     }
 
-    public RoomBroadcastTask(MucRoom room, String gameId, String roomId, KixmppJid from, String nickname, String...messages) {
-        super(room,gameId,roomId);
-        this.from = from;
-        this.nickname = nickname;
+    public RoomBroadcastTask(MucRoom room, String gameId, String roomId, KixmppJid fromJid, KixmppJid fromRoomJid, String nickname, String...messages) {
+        super(room, gameId, roomId);
+	    this.fromJid = fromJid;
+	    this.fromRoomJid = fromRoomJid;
+	    this.nickname = nickname;
         this.messages = messages;
     }
 
     @Override
     public void run() {
-        getRoom().receive(from, messages);
+        getRoom().receive(fromJid, fromRoomJid, messages);
     }
 
 	/**
-	 * @return the from
+	 * @return the fromJid
 	 */
-	public KixmppJid getFrom() {
-		return from;
+	public KixmppJid getFromJid() {
+		return fromJid;
 	}
 
 	/**
-	 * @param from the from to set
+	 * @return the fromRoomJid
 	 */
-	public void setFrom(KixmppJid from) {
-		this.from = from;
+	public KixmppJid getFromRoomJid() {
+		return fromRoomJid;
 	}
 
 	/**

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/DefaultMucRoomEventHandler.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/DefaultMucRoomEventHandler.java
@@ -44,12 +44,12 @@ public class DefaultMucRoomEventHandler implements MucRoomEventHandler {
 	}
 
 	@Override
-	public void handleMessage(MucRoom room, KixmppJid from, String... messages) {
+	public void handleMessage(MucRoom room, KixmppJid fromJid, KixmppJid fromRoomJid, String... messages) {
 		for (MucRoom.User user: room.getUsers()) {
 			for (MucRoom.Client client: user.getConnections()) {
 				for (String message: messages) {
 					Element stanza = createMessage(UUID.randomUUID().toString(),
-							from,
+							fromRoomJid,
 							client.getAddress(),
 							"groupchat",
 							message);

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucKixmppServerModule.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucKixmppServerModule.java
@@ -184,7 +184,7 @@ public class MucKixmppServerModule implements KixmppServerModule {
 
 			KixmppJid roomJid = new KixmppJid(broadcastTask.getRoomId(), broadcastTask.getServiceSubDomain() + "." + server.getDomain());
 			
-			publishMessage(roomJid, broadcastTask.getFrom(), broadcastTask.getNickname(), broadcastTask.getMessages());
+			publishMessage(roomJid, broadcastTask.getFromRoomJid(), broadcastTask.getNickname(), broadcastTask.getMessages());
 		}
 		
         MucService service = getService(roomTask.getServiceSubDomain());

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoomEventHandler.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoomEventHandler.java
@@ -23,7 +23,7 @@ package com.kixeye.kixmpp.server.module.muc;
 import com.kixeye.kixmpp.KixmppJid;
 
 public interface MucRoomEventHandler {
-	public void handleMessage(MucRoom room, KixmppJid from, String... messages);
+	public void handleMessage(MucRoom room, KixmppJid fromJid, KixmppJid fromRoomJid, String... messages);
 	public void userAdded(MucRoom room, MucRoom.User user);
 	public void userRemoved(MucRoom room, MucRoom.User user);
 }

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucService.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucService.java
@@ -40,6 +40,7 @@ public interface MucService {
 
     /**
      * Broadcast the given messages to all rooms {@link MucRoom}.
+     * @param jid
      * @param messages
      */
     public void broadcast(KixmppJid jid, String...messages);

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kixeye.kixmpp</groupId>
 	<artifactId>kixmpp-parent</artifactId>
-	<version>3.0.0</version>
+	<version>4.0.0</version>
 	<packaging>pom</packaging>
 	<name>KIXMPP Parent</name>
 	<description>


### PR DESCRIPTION
MucRoomEventHandler handleMessage function now takes fromJid as well as fromRoomJid as params, initial commit for MucRoom presence broadcast across the cluster