### PR TITLE
Fixing presence broadcast when a user leaves a muc

### DIFF
--- a/kixmpp-client/pom.xml
+++ b/kixmpp-client/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>5.0.1</version>
+		<version>5.0.2</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-core/pom.xml
+++ b/kixmpp-core/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>5.0.1</version>
+		<version>5.0.2</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-p2p/pom.xml
+++ b/kixmpp-p2p/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.kixeye.kixmpp</groupId>
         <artifactId>kixmpp-parent</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2</version>
     </parent>
 
     <developers>

--- a/kixmpp-server/pom.xml
+++ b/kixmpp-server/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.kixeye.kixmpp</groupId>
 		<artifactId>kixmpp-parent</artifactId>
-		<version>5.0.1</version>
+		<version>5.0.2</version>
 	</parent>
 
 	<developers>

--- a/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoom.java
+++ b/kixmpp-server/src/main/java/com/kixeye/kixmpp/server/module/muc/MucRoom.java
@@ -527,7 +527,7 @@ public class MucRoom {
 	        MucRole role = jidRoles.get(user.getBareJid());
 
 	        if (settings.isPresenceEnabled()) {
-		        broadcastPresence(user.getBareJid(), role, "unavailable");
+		        broadcastPresence(roomJid.withResource(user.getNickname()), role, "unavailable");
 	        }
 	        this.usersByNickname.remove(user.getNickname());
 	        this.jidAffiliations.remove(user.getBareJid());

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kixeye.kixmpp</groupId>
 	<artifactId>kixmpp-parent</artifactId>
-	<version>5.0.1</version>
+	<version>5.0.2</version>
 	<packaging>pom</packaging>
 	<name>KIXMPP Parent</name>
 	<description>


### PR DESCRIPTION
Fixing presence broadcast when a user leaves a muc, sending roomJid/{nickname} instead of bareUserJid